### PR TITLE
niv stable: update 08bcfe14 -> 1f99fd2f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "08bcfe14ae29450e742efd8b98b1fb299d6ea6b0",
-        "sha256": "0cs7xs9qpjlgb96qyhz588m75sw7jyfh3fssshzqfqkj4sqgjyby",
+        "rev": "1f99fd2fdbefd8ebb6ca640eaafbcdad6595ebca",
+        "sha256": "0anjm7nz7k86hyi8rfxifc13i79jwbqcw6s8936dn1flh31vpjax",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/08bcfe14ae29450e742efd8b98b1fb299d6ea6b0.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/1f99fd2fdbefd8ebb6ca640eaafbcdad6595ebca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unstable": {


### PR DESCRIPTION
## Motivation

Dependencies should be up to date.

## Changelog for stable:
Commits: [NixOS/nixpkgs-channels@08bcfe14...1f99fd2f](https://github.com/NixOS/nixpkgs-channels/compare/08bcfe14ae29450e742efd8b98b1fb299d6ea6b0...1f99fd2fdbefd8ebb6ca640eaafbcdad6595ebca)

* [`7dfb4447`](https://github.com/NixOS/nixpkgs-channels/commit/7dfb4447d6c1cf3096c75889948895fd9d39c0b5) openssl_1_0_2: mark as insecure; fixes NixOS/nixpkgs-channels#77503 (kinda)
* [`a6ac7bfb`](https://github.com/NixOS/nixpkgs-channels/commit/a6ac7bfb1ed5c53b3f2e87fdab49c59e9518fec0) signal-desktop: 1.30.1 -> 1.31.0
* [`1019f563`](https://github.com/NixOS/nixpkgs-channels/commit/1019f563915071297fcbee732e3ddb076e41b50d) signal-desktop: 1.31.0 -> 1.32.0
* [`3a820f04`](https://github.com/NixOS/nixpkgs-channels/commit/3a820f04e1d795e70b07320db1b32eb0a8dc1037) nixos/release-notes: fix a tiny typo
* [`0b6df0b4`](https://github.com/NixOS/nixpkgs-channels/commit/0b6df0b4bfefc1858c20f0e370e2e47ddbaa068c) nix-bash-completions: 0.6.7 -> 0.6.8 (NixOS/nixpkgs-channels#81019)
* [`c1746708`](https://github.com/NixOS/nixpkgs-channels/commit/c1746708b16e993c192661df608075e2c338bb4e) gitlab: 12.8.1 -> 12.8.2 (NixOS/nixpkgs-channels#81803)